### PR TITLE
feat: Decimal+Formatted 추가

### DIFF
--- a/Sources/NumberterKit/Core/FormatterProvider.swift
+++ b/Sources/NumberterKit/Core/FormatterProvider.swift
@@ -9,6 +9,18 @@ import Foundation
 
 public enum FormatterProvider {
 
+    /// 지정된 소수점 자리수를 가진 NumberFormatter를 반환합니다.
+    public static func decimal(fractionDigits: Int) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        formatter.groupingSeparator = ","
+        formatter.locale = Locale(identifier: "ko_KR")
+
+        return formatter
+    }
+
     /// 쉼표만 포함, 소수점 없음
     public static let integerDecimal: NumberFormatter = {
         let formatter = NumberFormatter()

--- a/Sources/NumberterKit/Extensions/Decimal/Decimal+Formatting.swift
+++ b/Sources/NumberterKit/Extensions/Decimal/Decimal+Formatting.swift
@@ -22,6 +22,18 @@ public extension Decimal {
         FormatterProvider.integerDecimal.string(from: NSDecimalNumber(decimal: self)) ?? self.description
     }
 
+    /// 지정된 소수점 자리수로 포맷된 문자열을 반환합니다.
+    ///
+    /// 내부적으로 `FormatterProvider.decimal(fractionDigits:)`를 사용합니다.
+    ///
+    /// ```swift
+    /// Decimal(1234.5678).formatted(fractionDigits: 2)  // "1,234.57"
+    /// ```
+    func formatted(fractionDigits: Int) -> String {
+        FormatterProvider.decimal(fractionDigits: fractionDigits)
+            .string(from: NSDecimalNumber(decimal: self)) ?? self.description
+    }
+
     /// 퍼센트 포맷 문자열을 반환합니다.
     ///
     /// - Parameter withSpacing: `%` 기호 앞에 공백을 넣을지 여부 (기본값: `false`)


### PR DESCRIPTION
Decimal에 formatted 관련 메서드를 추가하여 자유롭게 소수점 자리수를 조정할 수 있도록 하였습니다.

```
    /// 지정된 소수점 자리수로 포맷된 문자열을 반환합니다.
    ///
    /// 내부적으로 `FormatterProvider.decimal(fractionDigits:)`를 사용합니다.
    ///
    /// ```swift
    /// Decimal(1234.5678).formatted(fractionDigits: 2)  // "1,234.57"
    /// ```
    func formatted(fractionDigits: Int) -> String {
        FormatterProvider.decimal(fractionDigits: fractionDigits)
            .string(from: NSDecimalNumber(decimal: self)) ?? self.description
    }
```
